### PR TITLE
Fix Link Order for GCC in CMake

### DIFF
--- a/src/nvtt/tests/CMakeLists.txt
+++ b/src/nvtt/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ ADD_EXECUTABLE(cubemaptest cubemaptest.cpp)
 TARGET_LINK_LIBRARIES(cubemaptest nvcore nvmath nvimage nvtt)
 
 ADD_EXECUTABLE(nvhdrtest hdrtest.cpp)
-TARGET_LINK_LIBRARIES(nvhdrtest nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvhdrtest nvcore nvimage nvtt bc6h nvmath)
 
 INSTALL(TARGETS nvtestsuite nvhdrtest DESTINATION bin)
  

--- a/src/nvtt/tools/CMakeLists.txt
+++ b/src/nvtt/tools/CMakeLists.txt
@@ -1,21 +1,21 @@
 
 ADD_EXECUTABLE(nvcompress compress.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvcompress nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvcompress nvcore nvimage nvtt bc6h nvmath)
 
 ADD_EXECUTABLE(nvdecompress decompress.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvdecompress nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvdecompress nvcore nvimage nvtt bc6h nvmath)
 
 ADD_EXECUTABLE(nvddsinfo ddsinfo.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvddsinfo nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvddsinfo nvcore nvimage nvtt bc6h nvmath)
 
 ADD_EXECUTABLE(nvimgdiff imgdiff.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvimgdiff nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvimgdiff nvcore nvtt bc6h nvmath)
 
 ADD_EXECUTABLE(nvassemble assemble.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvassemble nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvassemble nvcore nvimage nvtt bc6h nvmath)
 
 ADD_EXECUTABLE(nvzoom resize.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nvzoom nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nvzoom nvcore nvimage nvtt bc6h nvmath)
 
 SET(TOOLS nvcompress nvdecompress nvddsinfo nvassemble nvzoom)
 
@@ -28,7 +28,7 @@ ENDIF(GLEW_FOUND AND GLUT_FOUND AND OPENGL_FOUND)
 
 
 ADD_EXECUTABLE(nv-gnome-thumbnailer thumbnailer.cpp cmdline.h)
-TARGET_LINK_LIBRARIES(nv-gnome-thumbnailer nvcore nvmath nvimage nvtt)
+TARGET_LINK_LIBRARIES(nv-gnome-thumbnailer nvcore nvtt nvimage bc6h nvmath)
 
 SET(TOOLS ${TOOLS} nv-gnome-thumbnailer)
 


### PR DESCRIPTION
Link order is relevant for GCC because it only does one linker pass. Generally, references have to come before definitions.

After these changes, tools link fine with GCC.