### PR TITLE
Do not redefine snprintf on VS2015

### DIFF
--- a/src/nvcore/DefsVcWin32.h
+++ b/src/nvcore/DefsVcWin32.h
@@ -19,7 +19,9 @@
 #define NV_CONST
 
 // Set standard function names.
-#define snprintf _snprintf
+#if _MSC_VER < 1900
+#   define snprintf _snprintf
+#endif
 #if _MSC_VER < 1500
 #   define vsnprintf _vsnprintf
 #endif


### PR DESCRIPTION
Visual Studio 2015 finally implements `snprintf`, so it may not be defined here.