### PR TITLE
Update NV_FOREACH for C++11

### DIFF
--- a/src/nvcore/ForEach.h
+++ b/src/nvcore/ForEach.h
@@ -10,10 +10,15 @@ These foreach macros are very non-standard and somewhat confusing, but I like th
 
 #include "nvcore.h"
 
-#if NV_CC_GNUC // If typeof is available:
+#if NV_CC_GNUC || NV_CC_CPP11 // If typeof or decltype is available:
+#if !NV_CC_CPP11
+#   define NV_DECLTYPE typeof // Using a non-standard extension over typeof that behaves as C++11 decltype
+#else
+#   define NV_DECLTYPE decltype
+#endif
 
 #define NV_FOREACH(i, container) \
-    typedef typeof(container) NV_STRING_JOIN2(cont,__LINE__); \
+    typedef NV_DECLTYPE(container) NV_STRING_JOIN2(cont,__LINE__); \
     for(NV_STRING_JOIN2(cont,__LINE__)::PseudoIndex i((container).start()); !(container).isDone(i); (container).advance(i))
 /*
 #define NV_FOREACH(i, container) \


### PR DESCRIPTION
This use of `typeof` relies on a non-standard extension in GCC, which mimics the behaviour of C++11's `decltype`. Recent version of GCC remove this extension, at least when C++11 is enabled and thus `decltype` is available.

This change was also tested on VS2015.

C++11's range-based for loops should probably preferred over this `foreach` construct, however it relies on containers having `begin` and `end` accessors, or `std::begin` and `std::end` being overloaded for the container type.