### PR TITLE
Do not include Library.h

### DIFF
--- a/src/nvtt/cuda/CudaUtils.cpp
+++ b/src/nvtt/cuda/CudaUtils.cpp
@@ -23,7 +23,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #include "nvcore/Debug.h"
-#include "nvcore/Library.h"
 #include "CudaUtils.h"
 
 #if defined HAVE_CUDA


### PR DESCRIPTION
`nvcore/Library.h` has been removed in commit 81336cc3e9cef439fc103ec40c8e6110cfdfe225, however it's still included by `nvtt/cuda/CudaUtils.cpp`.