### PR TITLE
Fix compilation on VS2013 (non-CUDA)

### DIFF
--- a/project/vc12/nvcore/nvcore.vcxproj
+++ b/project/vc12/nvcore/nvcore.vcxproj
@@ -154,7 +154,6 @@
     <ClInclude Include="..\..\..\src\nvcore\Debug.h" />
     <ClInclude Include="..\..\..\src\nvcore\DefsVcWin32.h" />
     <ClInclude Include="..\..\..\src\nvcore\FileSystem.h" />
-    <ClInclude Include="..\..\..\src\nvcore\Library.h" />
     <ClInclude Include="..\..\..\src\nvcore\Memory.h" />
     <ClInclude Include="..\..\..\src\nvcore\nvcore.h" />
     <ClInclude Include="..\..\..\src\nvcore\Ptr.h" />
@@ -166,7 +165,6 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\src\nvcore\Debug.cpp" />
     <ClCompile Include="..\..\..\src\nvcore\FileSystem.cpp" />
-    <ClCompile Include="..\..\..\src\nvcore\Library.cpp" />
     <ClCompile Include="..\..\..\src\nvcore\Memory.cpp" />
     <ClCompile Include="..\..\..\src\nvcore\StrLib.cpp" />
     <ClCompile Include="..\..\..\src\nvcore\TextWriter.cpp" />

--- a/project/vc12/nvdecompress/nvdecompress.vcxproj
+++ b/project/vc12/nvdecompress/nvdecompress.vcxproj
@@ -226,6 +226,14 @@
       <Project>{50c465fe-b308-42bc-894d-89484482af06}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\nvtt\nvtt.vcxproj">
+      <Project>{1aeb7681-57d8-48ee-813d-5c41cc38b647}</Project>
+      <Private>false</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/project/vc12/nvimgdiff/nvimgdiff.vcxproj
+++ b/project/vc12/nvimgdiff/nvimgdiff.vcxproj
@@ -228,6 +228,14 @@
       <Project>{50c465fe-b308-42bc-894d-89484482af06}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\nvtt\nvtt.vcxproj">
+      <Project>{1aeb7681-57d8-48ee-813d-5c41cc38b647}</Project>
+      <Private>false</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/project/vc12/nvtt.sln
+++ b/project/vc12/nvtt.sln
@@ -343,7 +343,4 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Removed Library.cpp and Library.h from nvcore VS2013 project
- Also added project references to nvtt in nvdecompress and nvimgdiff projects, lack of which prevented them from compiling
- Change to nvtt.sln is an auto-modification from VS, pretty sure it makes no difference