### PR TITLE
Memory leak corrected (was using wrong delete implementation) and other issues

### DIFF
--- a/src/nvimage/Filter.cpp
+++ b/src/nvimage/Filter.cpp
@@ -313,7 +313,7 @@ Kernel1::Kernel1(const Filter & f, int iscale, int samples/*= 32*/)
 
 Kernel1::~Kernel1()
 {
-    delete m_data;
+    delete [] m_data;
 }
 
 // Print the kernel for debugging purposes.
@@ -349,7 +349,7 @@ Kernel2::Kernel2(const Kernel2 & k) : m_windowSize(k.m_windowSize)
 
 Kernel2::~Kernel2()
 {
-    delete m_data;
+    delete [] m_data;
 }
 
 // Normalize the filter.

--- a/src/nvtt/squish/fastclusterfit.cpp
+++ b/src/nvtt/squish/fastclusterfit.cpp
@@ -143,11 +143,11 @@ void FastClusterFit::Compress3( void* block )
 	int i = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= 16; c0++)
+	for( int c0 = 0; c0 < 16; c0++)
 	{	
 		x1 = zero;
 		
-		for( int c1 = 0; c1 <= 16-c0; c1++)
+		for( int c1 = 0; c1 < 16-c0; c1++)
 		{
 			Vec4 const constants = Vec4((const float *)&s_threeElement[i]);
 			Vec4 const alpha2_sum = constants.SplatX();
@@ -256,15 +256,15 @@ void FastClusterFit::Compress4( void* block )
 	int i = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= 16; c0++)
+	for( int c0 = 0; c0 < 16; c0++)
 	{	
 		Vec4 x1 = zero;
 		
-		for( int c1 = 0; c1 <= 16-c0; c1++)
+		for( int c1 = 0; c1 < 16-c0; c1++)
 		{	
 			Vec4 x2 = zero;
 			
-			for( int c2 = 0; c2 <= 16-c0-c1; c2++)
+			for( int c2 = 0; c2 < 16-c0-c1; c2++)
 			{
 				Vec4 const constants = Vec4((const float *)&s_fourElement[i]);
 				Vec4 const alpha2_sum = constants.SplatX();
@@ -387,11 +387,11 @@ void FastClusterFit::Compress3( void* block )
 	int i = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= 16; c0++)
+	for( int c0 = 0; c0 < 16; c0++)
 	{	
 		x1 = Vec3(0);
 		
-		for( int c1 = 0; c1 <= 16-c0; c1++)
+		for( int c1 = 0; c1 < 16-c0; c1++)
 		{	
 			float const alpha2_sum = s_threeElement[i].alpha2_sum;
 			float const beta2_sum = s_threeElement[i].beta2_sum;
@@ -494,15 +494,15 @@ void FastClusterFit::Compress4( void* block )
 	int i = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= 16; c0++)
+	for( int c0 = 0; c0 < 16; c0++)
 	{	
 		x1 = Vec3(0.0f);
 		
-		for( int c1 = 0; c1 <= 16-c0; c1++)
+		for( int c1 = 0; c1 < 16-c0; c1++)
 		{	
 			x2 = Vec3(0.0f);
 			
-			for( int c2 = 0; c2 <= 16-c0-c1; c2++)
+			for( int c2 = 0; c2 < 16-c0-c1; c2++)
 			{
 				float const alpha2_sum = s_fourElement[i].alpha2_sum;
 				float const beta2_sum = s_fourElement[i].beta2_sum;

--- a/src/nvtt/squish/weightedclusterfit.cpp
+++ b/src/nvtt/squish/weightedclusterfit.cpp
@@ -149,11 +149,11 @@ void WeightedClusterFit::Compress3( void* block )
 	int b0 = 0, b1 = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= count; c0++)
+	for( int c0 = 0; c0 < count; c0++)
 	{	
 		Vec4 x1 = zero;
 		
-		for( int c1 = 0; c1 <= count-c0; c1++)
+		for( int c1 = 0; c1 < count-c0; c1++)
 		{
 			Vec4 const x2 = m_xsum - x1 - x0;
 			
@@ -264,15 +264,15 @@ void WeightedClusterFit::Compress4( void* block )
 	int b0 = 0, b1 = 0, b2 = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= count; c0++)
+	for( int c0 = 0; c0 < count; c0++)
 	{	
 		Vec4 x1 = zero;
 		
-		for( int c1 = 0; c1 <= count-c0; c1++)
+		for( int c1 = 0; c1 < count-c0; c1++)
 		{	
 			Vec4 x2 = zero;
 			
-			for( int c2 = 0; c2 <= count-c0-c1; c2++)
+			for( int c2 = 0; c2 < count-c0-c1; c2++)
 			{
 				Vec4 const x3 = m_xsum - x2 - x1 - x0;
 				
@@ -389,12 +389,12 @@ void WeightedClusterFit::Compress3( void* block )
 	int b0 = 0, b1 = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= count; c0++)
+	for( int c0 = 0; c0 < count; c0++)
 	{	
 		Vec3 x1(0.0f);
 		float w1 = 0.0f;
 		
-		for( int c1 = 0; c1 <= count-c0; c1++)
+		for( int c1 = 0; c1 < count-c0; c1++)
 		{	
 			float w2 = m_wsum - w0 - w1;
 			
@@ -492,17 +492,17 @@ void WeightedClusterFit::Compress4( void* block )
 	int b0 = 0, b1 = 0, b2 = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= count; c0++)
+	for( int c0 = 0; c0 < count; c0++)
 	{	
 		Vec3 x1(0.0f);
 		float w1 = 0.0f;
 		
-		for( int c1 = 0; c1 <= count-c0; c1++)
+		for( int c1 = 0; c1 < count-c0; c1++)
 		{	
 			Vec3 x2(0.0f);
 			float w2 = 0.0f;
 			
-			for( int c2 = 0; c2 <= count-c0-c1; c2++)
+			for( int c2 = 0; c2 < count-c0-c1; c2++)
 			{
 				float w3 = m_wsum - w0 - w1 - w2;
 				


### PR DESCRIPTION
Memory leak with delete, need to use delete [] not delete on 2 class (Kernel1 & Kernel2).

WeightedClusterFit compress function access array that can go over the
count limit, since count is x, you cannot access an array at position x,
so the correction change the for loop to instead using <= count, use <
count which correct the issue...