### PR TITLE
Fix loop condition in Compress4 functions - accessing array out of bounds

### DIFF
--- a/src/nvtt/squish/fastclusterfit.cpp
+++ b/src/nvtt/squish/fastclusterfit.cpp
@@ -256,15 +256,15 @@ void FastClusterFit::Compress4( void* block )
 	int i = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= 16; c0++)
+	for( int c0 = 0; c0 < 16; c0++)
 	{	
 		Vec4 x1 = zero;
 		
-		for( int c1 = 0; c1 <= 16-c0; c1++)
+		for( int c1 = 0; c1 < 16-c0; c1++)
 		{	
 			Vec4 x2 = zero;
 			
-			for( int c2 = 0; c2 <= 16-c0-c1; c2++)
+			for( int c2 = 0; c2 < 16-c0-c1; c2++)
 			{
 				Vec4 const constants = Vec4((const float *)&s_fourElement[i]);
 				Vec4 const alpha2_sum = constants.SplatX();

--- a/src/nvtt/squish/weightedclusterfit.cpp
+++ b/src/nvtt/squish/weightedclusterfit.cpp
@@ -264,15 +264,15 @@ void WeightedClusterFit::Compress4( void* block )
 	int b0 = 0, b1 = 0, b2 = 0;
 
 	// check all possible clusters for this total order
-	for( int c0 = 0; c0 <= count; c0++)
+	for( int c0 = 0; c0 < count; c0++)
 	{	
 		Vec4 x1 = zero;
 		
-		for( int c1 = 0; c1 <= count-c0; c1++)
+		for( int c1 = 0; c1 < count-c0; c1++)
 		{	
 			Vec4 x2 = zero;
 			
-			for( int c2 = 0; c2 <= count-c0-c1; c2++)
+			for( int c2 = 0; c2 < count-c0-c1; c2++)
 			{
 				Vec4 const x3 = m_xsum - x2 - x1 - x0;
 				


### PR DESCRIPTION
for loops in Compress4 function in both WeightedClusterFit and FastClusterFit iterate from 0 to m_colours->GetCount() (16) inclusively on array that has 16 values (index from 0 to 15).  This results in undefined behavior.