### PR TITLE
Fix compilation on GCC 6

### DIFF
--- a/src/nvimage/ImageIO.cpp
+++ b/src/nvimage/ImageIO.cpp
@@ -677,7 +677,7 @@ static Image * loadPNG(Stream & s)
     png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
     if (png_ptr == NULL) {
         //	nvDebug( "*** LoadPNG: Error allocating read buffer in file '%s'.\n", name );
-        return false;
+        return NULL;
     }
 
     // Allocate/initialize a memory block for the image information
@@ -685,14 +685,14 @@ static Image * loadPNG(Stream & s)
     if (info_ptr == NULL) {
         png_destroy_read_struct(&png_ptr, NULL, NULL);
         //	nvDebug( "*** LoadPNG: Error allocating image information for '%s'.\n", name );
-        return false;
+        return NULL;
     }
 
     // Set up the error handling
     if (setjmp(png_jmpbuf(png_ptr))) {
         png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
         //	nvDebug( "*** LoadPNG: Error reading png file '%s'.\n", name );
-        return false;
+        return NULL;
     }
 
     // Set up the I/O functions.


### PR DESCRIPTION
GCC 6 apparently doesn't want to cast booleans to pointers anymore. So this fixes it for us. See also our changeset: http://trac.wildfiregames.com/changeset/18364