### PR TITLE
Fix build on VC2015 (missing typedefs)

### DIFF
--- a/src/nvcore/DefsVcWin32.h
+++ b/src/nvcore/DefsVcWin32.h
@@ -1,4 +1,4 @@
-// This code is in the public domain -- Ignacio Castaño <castano@gmail.com>
+// This code is in the public domain -- Ignacio CastaÃ±o <castano@gmail.com>
 
 #ifndef NV_CORE_H
 #error "Do not include this file directly."
@@ -51,6 +51,8 @@
 #define NV_FORCEINLINE __forceinline
 
 #define NV_THREAD_LOCAL __declspec(thread)
+
+#include <stdint.h>
 
 /*
 // Type definitions


### PR DESCRIPTION
On VC2015 the project wouldn't build because of the missing typedefs.
This was tested on both 2013 and 2015.

_The first line diff is from github changing the encoding ?_