### PR TITLE
createNormalMap: fix for bad range of generated normal maps

### DIFF
--- a/src/nvimage/NormalMap.cpp
+++ b/src/nvimage/NormalMap.cpp
@@ -103,9 +103,9 @@ static FloatImage * createNormalMap(const FloatImage * img, FloatImage::WrapMode
 
             Vector3 n = normalize(Vector3(du, dv, heightScale));
 
-            img_out->pixel(0, x, y, 0) = n.x;
-            img_out->pixel(1, x, y, 0) = n.y;
-            img_out->pixel(2, x, y, 0) = n.z;
+            img_out->pixel(0, x, y, 0) = n.x * 0.5f + 0.5f;
+            img_out->pixel(1, x, y, 0) = n.y * 0.5f + 0.5f;
+            img_out->pixel(2, x, y, 0) = n.z * 0.5f + 0.5f;
         }
     }
 


### PR DESCRIPTION
This createNormalMap function is broken. It returns an image where components are in the [-1, 1] range, which can't be encoded in most BC formats. This change puts the components into a valid range for encoding.