### PR TITLE
Add virtual destructor to TaskDispatcher.

### DIFF
--- a/src/nvtt/nvtt.h
+++ b/src/nvtt/nvtt.h
@@ -380,6 +380,8 @@ namespace nvtt
     // (New in NVTT 2.1)
     struct TaskDispatcher
     {
+        virtual ~TaskDispatcher() {}
+
         virtual void dispatch(Task * task, void * context, int count) = 0;
     };
 


### PR DESCRIPTION
This removes a GCC warning about that missing while virtual functions exist.