### PR TITLE
Fix build error on macOS 10.13

### DIFF
--- a/src/nvconfig.h.in
+++ b/src/nvconfig.h.in
@@ -1,7 +1,11 @@
 #ifndef NV_CONFIG
 #define NV_CONFIG
 
+#if NV_OS_DARWIN && !NV_OS_IOS
+#cmakedefine01 HAVE_UNISTD_H
+#else
 #cmakedefine HAVE_UNISTD_H
+#endif
 #cmakedefine HAVE_STDARG_H
 #cmakedefine HAVE_SIGNAL_H
 #cmakedefine HAVE_EXECINFO_H


### PR DESCRIPTION
This fixes macOS 10.13 builds that now require `HAVE_UNISTD_H` be assigned a value.