### PR TITLE
Fix .hdr images being loaded as LDR before compression

### DIFF
--- a/src/nvimage/ImageIO.cpp
+++ b/src/nvimage/ImageIO.cpp
@@ -1913,6 +1913,12 @@ FloatImage * nv::ImageIO::loadFloat(const char * fileName, Stream & s)
     }
 #endif
 
+#if defined(HAVE_STBIMAGE)
+    if (strCaseDiff(extension, ".hdr") == 0) {
+        return loadFloatSTB(s);
+    }
+#endif
+
 #if defined(HAVE_FREEIMAGE)
     FREE_IMAGE_FORMAT fif = FreeImage_GetFIFFromFilename(fileName);
     if (fif != FIF_UNKNOWN && FreeImage_FIFSupportsReading(fif)) {


### PR DESCRIPTION
Hello Ignacio,

It seems .hdr files (Radiance file format) are always converted to LDR before compression (through STB), I made a fix for that. It looks like the correct loading function was almost finished, as there was a loadFloatSTB() function implemented but never called ;)

I tested with this command-line:
`nvcompress -bc6 <hdr image>`

The issue is quite visible because STB also applies a gamma correction when converting to LDR, making the BC6-compressed image brighter than the original HDR file.

Cheers,
Rémi