### PR TITLE
Fix compilation on Linux - missing include, semicolon

### DIFF
--- a/src/nvcore/Memory.cpp
+++ b/src/nvcore/Memory.cpp
@@ -131,7 +131,7 @@ void * nv::aligned_malloc(size_t size, size_t alignment)
     posix_memalign(&ptr, alignment, size);
     return ptr;
 #elif NV_OS_LINUX
-    return memalign(alignment, size)
+    return memalign(alignment, size);
 #else // NV_OS_ORBIS || NV_OS_IOS
     // @@ IC: iOS appears to be 16 byte aligned, should we check alignment and assert if we request a higher alignment factor?
     return ::malloc(size);

--- a/src/nvcore/Memory.h
+++ b/src/nvcore/Memory.h
@@ -10,6 +10,10 @@
 #include <string.h> // memset
 //#include <stddef.h> // size_t
 
+#if NV_OS_LINUX
+#include <malloc.h> // memalign()
+#endif
+
 //#include <new>	// new and delete
 
 #define TRACK_MEMORY_LEAKS 0


### PR DESCRIPTION
Commit https://github.com/castano/nvidia-texture-tools/commit/9489aed825c6a0a931dfdd75e8ab6f97292b31a7 apparently broke compilation/linking on both Linux
and Windows. Fix for Linux at least.

According to http://man7.org/linux/man-pages/man3/memalign.3.html ,
memalign() is defined in malloc.h.
Also, the line should be terminated with a semicolon.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>