### PR TITLE
Enable CUDA support.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ SUBDIRS(bc7)
 #ENDIF(CG_FOUND)
 
 # CUDA
-#FIND_PACKAGE(CUDA)
+FIND_PACKAGE(CUDA)
 IF(CUDA_FOUND)
     IF(MINGW)
         MESSAGE(STATUS "Looking for CUDA - not supported on MinGW")

--- a/src/nvcore/CMakeLists.txt
+++ b/src/nvcore/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(CORE_SRCS
     DefsVcWin32.h
     FileSystem.h FileSystem.cpp
     ForEach.h
+    Library.h Library.cpp
     Memory.h Memory.cpp
     Ptr.h
     RefCounted.h

--- a/src/nvcore/Library.cpp
+++ b/src/nvcore/Library.cpp
@@ -1,0 +1,44 @@
+#include "Library.h"
+#include "Debug.h"
+
+#if NV_OS_WIN32
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#include <windows.h>
+#elif NV_OS_XBOX
+#include <Xtl.h>
+#else
+#include <dlfcn.h>
+#endif
+
+
+
+void * nvLoadLibrary(const char * name)
+{
+#if NV_OS_WIN32
+    return (void *)LoadLibraryExA( name, NULL, 0 );
+#elif NV_OS_XBOX
+    return (void *)LoadLibraryA( name );
+#else
+    return dlopen(name, RTLD_LAZY);
+#endif
+}
+
+void nvUnloadLibrary(void * handle)
+{
+    nvDebugCheck(handle != NULL);
+#if NV_OS_WIN32 || NV_OS_XBOX
+    FreeLibrary((HMODULE)handle);
+#else
+    dlclose(handle);
+#endif
+}
+
+void * nvBindSymbol(void * handle, const char * symbol)
+{
+#if NV_OS_WIN32 || NV_OS_XBOX
+    return (void *)GetProcAddress((HMODULE)handle, symbol);
+#else
+    return (void *)dlsym(handle, symbol);
+#endif
+}

--- a/src/nvcore/Library.h
+++ b/src/nvcore/Library.h
@@ -1,0 +1,51 @@
+// This code is in the public domain -- castano@gmail.com
+
+#pragma once
+#ifndef NV_CORE_LIBRARY_H
+#define NV_CORE_LIBRARY_H
+
+#include "nvcore.h"
+
+#if NV_OS_WIN32
+#define LIBRARY_NAME(name)	#name ".dll"
+#elif NV_OS_DARWIN
+#define NV_LIBRARY_NAME(name)	"lib" #name ".dylib"
+#else
+#define NV_LIBRARY_NAME(name)	"lib" #name ".so"
+#endif
+
+NVCORE_API void * nvLoadLibrary(const char * name);
+NVCORE_API void nvUnloadLibrary(void * lib);
+NVCORE_API void * nvBindSymbol(void * lib, const char * symbol);
+
+class NVCORE_CLASS Library
+{
+public:
+    Library(const char * name)
+    {
+        handle = nvLoadLibrary(name);
+    }
+    ~Library()
+    {
+        if (isValid())
+        {
+            nvUnloadLibrary(handle);
+        }
+    }
+
+    bool isValid() const
+    {
+        return handle != NULL;
+    }
+
+    void * bindSymbol(const char * symbol)
+    {
+        return nvBindSymbol(handle, symbol);
+    }
+
+private:
+    void * handle;
+};
+
+
+#endif // NV_CORE_LIBRARY_H

--- a/src/nvtt/cuda/CudaUtils.cpp
+++ b/src/nvtt/cuda/CudaUtils.cpp
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #include "nvcore/Debug.h"
+#include "nvcore/Library.h"
 #include "CudaUtils.h"
 
 #if defined HAVE_CUDA


### PR DESCRIPTION
This commit also reintroduces nvcore Library.h and Library.cpp files
required by nvtt/cuda/CudaUtils.cpp

Ref:
https://github.com/castano/nvidia-texture-tools/issues/230
https://github.com/castano/nvidia-texture-tools/commit/81336cc3e9cef439fc103ec40c8e6110cfdfe225

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>