### PR TITLE
Updated C-API to expose some functionality present in the C++ API

### DIFF
--- a/src/nvtt/nvtt_wrapper.cpp
+++ b/src/nvtt/nvtt_wrapper.cpp
@@ -27,9 +27,9 @@
 
 #include "OutputOptions.h"
 
-// An OutputHandler that sets and calls function pointers, rather than
-// requiring interfaces to derive from OutputHandler itself
-struct HandlerProxy : public nvtt::OutputHandler
+// An OutputHandler/ErrorHandler that sets and calls function pointers, rather than
+// requiring interfaces to derive from OutputHandler/ErrorHandler itself
+struct HandlerProxy : public nvtt::OutputHandler, public nvtt::ErrorHandler
 {
 public:
 
@@ -38,6 +38,8 @@ public:
     nvttBeginImageHandler beginImageHandler;
     nvttOutputHandler writeDataHandler;
     nvttEndImageHandler endImageHandler;
+
+    nvttErrorHandler errorHandler;
 
     virtual void beginImage(int size, int width, int height, int depth, int face, int miplevel)
     {
@@ -62,6 +64,14 @@ public:
         if (endImageHandler != NULL) 
         {
             endImageHandler();
+        }
+    }
+
+    virtual void error(nvtt::Error e) 
+    {
+        if (errorHandler != NULL)
+        {
+            errorHandler((NvttError)e);
         }
     }
 };
@@ -233,12 +243,32 @@ void nvttSetOutputOptionsOutputHeader(NvttOutputOptions * outputOptions, NvttBoo
 {
     outputOptions->setOutputHeader(b != NVTT_False);
 }
-/*
+
+void nvttSetOutputOptionsContainer(NvttOutputOptions * outputOptions, NvttContainer containerFormat)
+{
+    outputOptions->setContainer((nvtt::Container)containerFormat);
+}
+
+void nvttSetOutputOptionsSrgbFlag(NvttOutputOptions * outputOptions, NvttBoolean b)
+{
+    outputOptions->setSrgbFlag(b != NVTT_False);
+}
+
 void nvttSetOutputOptionsErrorHandler(NvttOutputOptions * outputOptions, nvttErrorHandler errorHandler)
 {
-    outputOptions->setErrorHandler(errorHandler);
+    HandlerProxy * handler = (HandlerProxy *)outputOptions->m.wrapperProxy;
+
+    handler->errorHandler = errorHandler;
+
+    if (errorHandler == NULL) 
+    {
+        outputOptions->setErrorHandler(NULL);
+    }
+    else
+    {
+        outputOptions->setErrorHandler(handler);
+    }
 }
-*/
 
 void nvttSetOutputOptionsOutputHandler(NvttOutputOptions * outputOptions, nvttBeginImageHandler beginImageHandler, nvttOutputHandler writeDataHandler, nvttEndImageHandler endImageHandler)
 {
@@ -268,6 +298,16 @@ NvttCompressor * nvttCreateCompressor()
 void nvttDestroyCompressor(NvttCompressor * compressor)
 {
     delete compressor;
+}
+
+void nvttEnableCudaAcceleration(NvttCompressor * compressor, NvttBoolean b)
+{
+    compressor->enableCudaAcceleration(b != NVTT_False);
+}
+
+NvttBoolean nvttIsCudaAccelerationEnabled(const NvttCompressor* compressor)
+{
+    return (NvttBoolean)compressor->isCudaAccelerationEnabled();
 }
 
 NvttBoolean nvttCompress(const NvttCompressor * compressor, const NvttInputOptions * inputOptions, const NvttCompressionOptions * compressionOptions, const NvttOutputOptions * outputOptions)

--- a/src/nvtt/nvtt_wrapper.h
+++ b/src/nvtt/nvtt_wrapper.h
@@ -171,17 +171,25 @@ typedef enum
 	NVTT_AlphaMode_Premultiplied,
 } NvttAlphaMode;
 
+// Error codes.
 typedef enum
 {
+    NVTT_Error_Unknown,
 	NVTT_Error_InvalidInput,
-	NVTT_Error_UserInterruption,
 	NVTT_Error_UnsupportedFeature,
 	NVTT_Error_CudaError,
-	NVTT_Error_Unknown,
 	NVTT_Error_FileOpen,
 	NVTT_Error_FileWrite,
     NVTT_Error_UnsupportedOutputFormat,
 } NvttError;
+
+// Output container format types.
+typedef enum
+{
+    NVTT_Container_DDS,
+    NVTT_Container_DDS10,
+    NVTT_Container_KTX,
+} NvttContainer;
 
 typedef enum
 {
@@ -195,7 +203,7 @@ extern "C" {
 #endif
 
 // Callbacks
-//typedef void (* nvttErrorHandler)(NvttError e);
+typedef void (* nvttErrorHandler)(NvttError e);
 typedef void (* nvttBeginImageHandler)(int size, int width, int height, int depth, int face, int miplevel);
 typedef bool (* nvttOutputHandler)(const void * data, int size);
 typedef void (* nvttEndImageHandler)();
@@ -241,7 +249,9 @@ NVTT_API void nvttDestroyOutputOptions(NvttOutputOptions * outputOptions);
 
 NVTT_API void nvttSetOutputOptionsFileName(NvttOutputOptions * outputOptions, const char * fileName);
 NVTT_API void nvttSetOutputOptionsOutputHeader(NvttOutputOptions * outputOptions, NvttBoolean b);
-//NVTT_API void nvttSetOutputOptionsErrorHandler(NvttOutputOptions * outputOptions, nvttErrorHandler errorHandler);
+NVTT_API void nvttSetOutputOptionsContainer(NvttOutputOptions * outputOptions, NvttContainer containerFormat);
+NVTT_API void nvttSetOutputOptionsSrgbFlag(NvttOutputOptions * outputOptions, NvttBoolean b);
+NVTT_API void nvttSetOutputOptionsErrorHandler(NvttOutputOptions * outputOptions, nvttErrorHandler errorHandler);
 NVTT_API void nvttSetOutputOptionsOutputHandler(NvttOutputOptions * outputOptions, nvttBeginImageHandler beginImageHandler, nvttOutputHandler outputHandler, nvttEndImageHandler endImageHandler);
 
 
@@ -249,6 +259,8 @@ NVTT_API void nvttSetOutputOptionsOutputHandler(NvttOutputOptions * outputOption
 NVTT_API NvttCompressor * nvttCreateCompressor();
 NVTT_API void nvttDestroyCompressor(NvttCompressor * compressor);
 
+NVTT_API void nvttEnableCudaAcceleration(NvttCompressor * compressor, NvttBoolean b);
+NVTT_API NvttBoolean nvttIsCudaAccelerationEnabled(const NvttCompressor* compressor);
 NVTT_API NvttBoolean nvttCompress(const NvttCompressor * compressor, const NvttInputOptions * inputOptions, const NvttCompressionOptions * compressionOptions, const NvttOutputOptions * outputOptions);
 NVTT_API int nvttEstimateSize(const NvttCompressor * compressor, const NvttInputOptions * inputOptions, const NvttCompressionOptions * compressionOptions);
 


### PR DESCRIPTION
Hello there!

I recently found out that the library actually supported outputting KTX files and not just DDS (I only use the C-API). I did a pass on other stuff that was missing from the C-API as well.

Added the following functions and enums:

nvttSetOutputOptionsContainer [and NvttContainer, KTX/DDS10 formats can now be set as the output container]
nvttSetOutputOptionsSrgbFlag
nvttSetOutputOptionsErrorHandler [rearranged NvttError enum to match layout of nvtt::error]
nvttEnableCudaAcceleration
nvttIsCudaAccelerationEnabled