### PR TITLE
Added support for MCST Elbrus 2000 (e2k) architecture

### DIFF
--- a/extern/poshlib/posh.h
+++ b/extern/poshlib/posh.h
@@ -87,6 +87,7 @@ GNU GCC/G++:
    - m68000: 68K
    - m68k: 68K
    - __palmos__: PalmOS
+   - __e2k__: on MCST Elbrus 2000 processor platforms
 
 Intel C/C++ Compiler:
    - __ECC      : compiler version, IA64 only
@@ -206,6 +207,11 @@ Metrowerks:
 LLVM:
    - __llvm__
    - __clang__
+
+LCC predefines the following:
+   - __LCC__:
+   if also defined e2k it is MCST eLbrus C Compiler
+   else                it is Local (or Little) C Compiler
 */
 
 /*
@@ -549,6 +555,11 @@ LLVM:
 #  define POSH_CPU_STRING "PA-RISC"
 #endif
 
+#if defined __e2k__
+#  define POSH_CPU_E2K 1
+#  define POSH_CPU_STRING "MCST Elbrus 2000"
+#endif
+
 #if !defined POSH_CPU_STRING
 #  error POSH cannot determine target CPU
 #  define POSH_CPU_STRING "Unknown" /* this is here for Doxygen's benefit */
@@ -686,7 +697,7 @@ LLVM:
 ** the MIPS series, so we have to be careful about those.
 ** ----------------------------------------------------------------------------
 */
-#if defined POSH_CPU_X86 || defined POSH_CPU_AXP || defined POSH_CPU_STRONGARM || defined POSH_CPU_AARCH64 || defined POSH_OS_WIN32 || defined POSH_OS_WINCE || defined __MIPSEL__ || defined __ORDER_LITTLE_ENDIAN__
+#if defined POSH_CPU_X86 || defined POSH_CPU_AXP || defined POSH_CPU_STRONGARM || defined POSH_CPU_AARCH64 || defined POSH_OS_WIN32 || defined POSH_OS_WINCE || defined __MIPSEL__ || defined __ORDER_LITTLE_ENDIAN__ || defined POSH_CPU_E2K
 #  define POSH_ENDIAN_STRING "little"
 #  define POSH_LITTLE_ENDIAN 1
 #else
@@ -714,7 +725,7 @@ LLVM:
 ** for 64-bit support, we ignore the POSH_USE_LIMITS_H directive.
 ** ----------------------------------------------------------------------------
 */
-#if defined ( __LP64__ ) || defined ( __powerpc64__ ) || defined POSH_CPU_SPARC64
+#if defined ( __LP64__ ) || defined ( __powerpc64__ ) || defined POSH_CPU_SPARC64 || defined POSH_CPU_E2K
 #  define POSH_64BIT_INTEGER 1
 typedef long posh_i64_t; 
 typedef unsigned long posh_u64_t;
@@ -883,7 +894,7 @@ POSH_COMPILE_TIME_ASSERT(posh_i32_t, sizeof(posh_i32_t) == 4);
 #  define POSH_64BIT_POINTER 1
 #endif
 
-#if defined POSH_CPU_SPARC64 || defined POSH_OS_WIN64 || defined __64BIT__ || defined __LP64 || defined _LP64 || defined __LP64__ || defined _ADDR64 || defined _CRAYC
+#if defined POSH_CPU_SPARC64 || defined POSH_OS_WIN64 || defined __64BIT__ || defined __LP64 || defined _LP64 || defined __LP64__ || defined _ADDR64 || defined _CRAYC || defined POSH_CPU_E2K
 #   define POSH_64BIT_POINTER 1
 #endif
 

--- a/src/nvcore/Debug.cpp
+++ b/src/nvcore/Debug.cpp
@@ -668,6 +668,13 @@ namespace
 #    elif NV_CPU_AARCH64
         ucontext_t * ucp = (ucontext_t *)secret;
         return (void *) ucp->uc_mcontext.pc;
+#   elif NV_CPU_E2K /* MCST Elbrus 2000 */
+        // e2k has 3 stacks - Procedure Stack (PS), Procedure Chain Stack (PCS) and User Stack (US)
+        // CR0 and CR1 (Chain Register) are the 128-bit registers of the Procedure Chain Stack (PCS)
+        // CR's divided into _HI and _LO 64-bit parts (as in x86, for example, AX is divided into AH and AL)
+        // CR0_HI stores an Instruction Pointer
+        ucontext_t * ucp = (ucontext_t *)secret;
+        return (void *) ucp->uc_mcontext.cr0_hi;
 #    else
 #      error "Unknown CPU"
 #    endif

--- a/src/nvcore/nvcore.h
+++ b/src/nvcore/nvcore.h
@@ -98,6 +98,7 @@
 // NV_CPU_PPC
 // NV_CPU_ARM
 // NV_CPU_ARM_64
+// NV_CPU_E2K
 
 #define NV_CPU_STRING   POSH_CPU_STRING
 
@@ -112,6 +113,8 @@
 #   define NV_CPU_ARM 1
 #elif defined POSH_CPU_AARCH64
 #   define NV_CPU_ARM_64 1
+#elif defined POSH_CPU_E2K
+#   define NV_CPU_E2K 1
 #else
 #   error "Unsupported CPU"
 #endif

--- a/src/nvthread/Atomic.h
+++ b/src/nvthread/Atomic.h
@@ -61,7 +61,7 @@ namespace nv {
 #elif POSH_CPU_STRONGARM || POSH_CPU_AARCH64
         // need more specific cpu type for armv7?
         // also utilizes a full barrier
-        // currently treating laod like x86 - this could be wrong
+        // currently treating load like x86 - this could be wrong
         
         // this is the easiest but slowest way to do this
         nvCompilerReadWriteBarrier();
@@ -76,6 +76,16 @@ namespace nv {
         // this is the easiest but slowest way to do this
         nvCompilerReadWriteBarrier();
 		uint32 ret = *ptr; // replace with ldrex?
+        nvCompilerReadWriteBarrier();
+        return ret;
+#elif POSH_CPU_E2K
+        // need more specific cpu type for e2k?
+        // also utilizes a full barrier
+        // currently treating load like x86 - this could be wrong
+
+        // this is the easiest but slowest way to do this
+        nvCompilerReadWriteBarrier();
+        uint32 ret = *ptr; // replace with ldrex?
         nvCompilerReadWriteBarrier();
         return ret;
 #else
@@ -102,6 +112,11 @@ namespace nv {
         nvCompilerReadWriteBarrier();
 		*ptr = value; //strex?
 		nvCompilerReadWriteBarrier();
+#elif POSH_CPU_E2K
+        // this is the easiest but slowest way to do this
+        nvCompilerReadWriteBarrier();
+        *ptr = value; //strex?
+        nvCompilerReadWriteBarrier();
 #else
 #error "Atomics not implemented."
 #endif


### PR DESCRIPTION
Added MCST Elbrus 2000 (e2k) architecture initial support. This is VLIW/EPIC architecture like Intel Itanium architecture.

About this architecture:
- https://en.wikipedia.org/wiki/Elbrus_2000

The following files have been modified for e2k support:
- \extern\poshlib\posh.h
- \src\nvcore\Debug.cpp
- \src\nvcore\nvcore.h
- \src\nvthread\Atomic.h

Attached the log of successful compilation on e2k:
[compile_e2k.log](https://github.com/castano/nvidia-texture-tools/files/3882508/compile_e2k.log)