### PR TITLE
Fix build on AArch64. Fixes #298.

### DIFF
--- a/src/nvcore/Debug.cpp
+++ b/src/nvcore/Debug.cpp
@@ -1015,6 +1015,12 @@ void debug::dumpInfo()
 #endif
 }
 
+static void getEmptyVAList(va_list& list, ...)
+{
+    va_start(list, list);
+    va_end(list);
+}
+
 /// Dump callstack using the specified handler.
 void debug::dumpCallstack(MessageHandler *messageHandler, int callstackLevelsToSkip /*= 0*/)
 {
@@ -1027,8 +1033,11 @@ void debug::dumpCallstack(MessageHandler *messageHandler, int callstackLevelsToS
         Array<const char *> lines;
         writeStackTrace(trace, size, callstackLevelsToSkip + 1, lines);     // + 1 to skip the call to dumpCallstack
 
+        va_list empty;
+        getEmptyVAList(empty);
+
         for (uint i = 0; i < lines.count(); i++) {
-            messageHandler->log(lines[i], NULL);
+            messageHandler->log(lines[i], empty);
             delete lines[i];
         }
     }

--- a/src/nvcore/Debug.h
+++ b/src/nvcore/Debug.h
@@ -166,7 +166,7 @@ NVCORE_API void NV_CDECL nvDebugPrint( const char *msg, ... ) __attribute__((for
 namespace nv
 {
     inline bool isValidPtr(const void * ptr) {
-    #if NV_CPU_X86_64 || POSH_CPU_PPC64
+    #if NV_CPU_X86_64 || POSH_CPU_PPC64 || NV_CPU_AARCH64
         if (ptr == NULL) return true;
         if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
         if (reinterpret_cast<uint64>(ptr) >= 0x000007FFFFFEFFFFULL) return false;


### PR DESCRIPTION
Instantiating a `va_list` with `NULL` makes assumptions about the implementation specific type that might not be valid everywhere and are not on aarch64.

The pointer validity check is probably too narrow, but that also applies to x86_64 and ppc64.