### PR TITLE
Fix some bugs when compiling with latest clang on macOS.

### DIFF
--- a/src/nvimage/Image.cpp
+++ b/src/nvimage/Image.cpp
@@ -44,13 +44,13 @@ void Image::allocate(uint w, uint h, uint d/*= 1*/)
     data = realloc<Color32>(data, w * h * d);
 }
 
-void Image::acquire(Color32 * data, uint w, uint h, uint d/*= 1*/)
+void Image::acquire(Color32 * rawdata, uint w, uint h, uint d/*= 1*/)
 {
     free();
     width = w;
     height = h;
     depth = d;
-    data = data;
+    data = rawdata;
 }
 
 void Image::free()

--- a/src/nvtt/CompressorDXT1.cpp
+++ b/src/nvtt/CompressorDXT1.cpp
@@ -5,6 +5,7 @@
 #include "nvmath/nvmath.h"
 
 #include <string.h> // memset
+#include <limits.h> // INT_MAX
 #include <float.h> // FLT_MAX
 
 
@@ -54,6 +55,26 @@ namespace nv {
     /*struct Vector3 {
         float x, y, z;
     };*/
+
+    inline Vector3::Vector3() {}
+    inline Vector3::Vector3(float f) : x(f), y(f), z(f) {}
+    inline Vector3::Vector3(float x, float y, float z) : x(x), y(y), z(z) {}
+    inline Vector3::Vector3(Vector3::Arg v) : x(v.x), y(v.y), z(v.z) {}
+
+    inline const Vector3 & Vector3::operator=(Vector3::Arg v)
+    {
+        x = v.x;
+        y = v.y;
+        z = v.z;
+        return *this;
+    }
+
+    inline void Vector3::operator+=(Vector3::Arg v)
+    {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+    }
 
     inline Vector3 operator*(Vector3 v, float s) {
         return { v.x * s, v.y * s, v.z * s };
@@ -105,6 +126,13 @@ namespace nv {
 
     inline void Vector3::set(float x, float y, float z) {
         this->x = x; this->y = y; this->z = z;
+    }
+
+    inline Vector4::Vector4(Vector3::Arg v, float w) : x(v.x), y(v.y), z(v.z), w(w) {}
+
+    inline Vector3 Vector4::xyz() const
+    {
+        return Vector3(x, y, z);
     }
 
 }

--- a/src/nvtt/tests/bc1enc.cpp
+++ b/src/nvtt/tests/bc1enc.cpp
@@ -46,6 +46,11 @@ typedef unsigned int u32;
 #define TEST_AMD_CMP 1
 
 
+namespace nv
+{
+    inline Vector3::Vector3(float f) : x(f), y(f), z(f) {}
+    inline Vector4::Vector4() {}
+}
 
 static float mse_to_psnr(float mse) {
     float rms = sqrtf(mse);


### PR DESCRIPTION
 Add missing header and inline functions in CompressorDXT1, fix compile error on macOS.