### PR TITLE
fix typo (name duplicated)

### DIFF
--- a/src/nvimage/Image.cpp
+++ b/src/nvimage/Image.cpp
@@ -44,13 +44,13 @@ void Image::allocate(uint w, uint h, uint d/*= 1*/)
     data = realloc<Color32>(data, w * h * d);
 }
 
-void Image::acquire(Color32 * data, uint w, uint h, uint d/*= 1*/)
+void Image::acquire(Color32 * inData, uint w, uint h, uint d/*= 1*/)
 {
     free();
     width = w;
     height = h;
     depth = d;
-    data = data;
+    data = inData;
 }
 
 void Image::free()


### PR DESCRIPTION
input argument name(data) was duplicated with class member(data).