### PR TITLE
Better AARCH64/Arm64 support.

### DIFF
--- a/src/nvcore/Debug.cpp
+++ b/src/nvcore/Debug.cpp
@@ -604,10 +604,7 @@ namespace
 #    elif NV_CPU_X86
         ucontext_t * ucp = (ucontext_t *)secret;
         return (void *) ucp->uc_mcontext->__ss.__eip;
-#    elif NV_CPU_ARM
-        ucontext_t * ucp = (ucontext_t *)secret;
-        return (void *) ucp->uc_mcontext->__ss.__pc;
-#    elif NV_CPU_AARCH64
+#    elif NV_CPU_ARM || NV_CPU_AARCH64
         ucontext_t * ucp = (ucontext_t *)secret;
         return (void *) ucp->uc_mcontext->__ss.__pc;
 #    else

--- a/src/nvcore/Debug.cpp
+++ b/src/nvcore/Debug.cpp
@@ -607,6 +607,9 @@ namespace
 #    elif NV_CPU_ARM
         ucontext_t * ucp = (ucontext_t *)secret;
         return (void *) ucp->uc_mcontext->__ss.__pc;
+#    elif NV_CPU_AARCH64
+        ucontext_t * ucp = (ucontext_t *)secret;
+        return (void *) ucp->uc_mcontext->__ss.__pc;
 #    else
 #      error "Unknown CPU"
 #    endif

--- a/src/nvcore/nvcore.h
+++ b/src/nvcore/nvcore.h
@@ -97,7 +97,7 @@
 // NV_CPU_X86_64
 // NV_CPU_PPC
 // NV_CPU_ARM
-// NV_CPU_ARM_64
+// NV_CPU_AARCH64
 // NV_CPU_E2K
 
 #define NV_CPU_STRING   POSH_CPU_STRING
@@ -112,7 +112,7 @@
 #elif defined POSH_CPU_STRONGARM
 #   define NV_CPU_ARM 1
 #elif defined POSH_CPU_AARCH64
-#   define NV_CPU_ARM_64 1
+#   define NV_CPU_AARCH64 1
 #elif defined POSH_CPU_E2K
 #   define NV_CPU_E2K 1
 #else


### PR DESCRIPTION
Added `NV_CPU_AARCH64` support for Mac OS X/Darwin to NVCore's Debug.cpp
Renamed `NV_CPU_ARM_64` to `NV_CPU_AARCH64`