### PR TITLE
Fix data testsuite path

### DIFF
--- a/src/nvtt/tests/testsuite.cpp
+++ b/src/nvtt/tests/testsuite.cpp
@@ -509,6 +509,9 @@ int main(int argc, char *argv[])
     nvtt::Context context;
     context.enableCudaAcceleration(!nocuda);
 
+    if (basePath.length() > 0) {
+        basePath.appendSeparator();
+    }
     basePath.append(set.basePath);
 
     FileSystem::changeDirectory(basePath.str());


### PR DESCRIPTION
Add separator between base path and set path if base path is set

Fixes #299

This was spotted in Gentoo version bump, bug https://bugs.gentoo.org/show_bug.cgi?id=740766